### PR TITLE
Fixed README.

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,3 @@
-LATEST VERSION MOVED TO https://github.com/SublimeText/CloseTagOnSlash
-
-
-
 This is a command for Sublime Text 2 that is meant to be bound to the slash
 ("/") key in order to semi auto close open HTML tags (in part inspired by the
 discussion at http://www.sublimetext.com/forum/viewtopic.php?f=5&t=1358).


### PR DESCRIPTION
The move to https://github.com/organizations/SublimeText has been completed. Therefore removed previous message about the move...
