### PR TITLE
Using slash key should only remove </ on success

### DIFF
--- a/tag_close_tag_on_slash.py
+++ b/tag_close_tag_on_slash.py
@@ -1,30 +1,39 @@
-import sublime, sublime_plugin, re
+import sublime
+import sublime_plugin
+import re
+
 
 class TagCloseTagOnSlashCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		closeTags = False;
-		for region in self.view.sel():
-			cursorPosition = region.begin()
-			previousCharacter = self.view.substr(sublime.Region(cursorPosition - 1, cursorPosition))
+    def run(self, edit):
 
-			if '<' == previousCharacter and self.view.score_selector(cursorPosition, 'text.html | text.xml') > 0:
-				syntax = self.view.syntax_name(region.begin())
-				should_skip = re.match(".*string.quoted.double", syntax) or re.match(".*string.quoted.single", syntax)
-				if not should_skip:
-					self.view.erase(edit, sublime.Region(cursorPosition - 1, cursorPosition))
-					closeTags = True;
-				else:
-					if region.empty():
-						self.view.insert(edit, cursorPosition, '/');
-					else:
-						self.view.replace(edit, sublime.Region(region.begin(), region.end()), '/');
-			else:
-				if region.empty():
-					self.view.insert(edit, cursorPosition, '/');
-				else:
-					self.view.replace(edit, sublime.Region(region.begin(), region.end()), '/');
-		if closeTags:
-			self.view.run_command('close_tag');
-			if self.view.window():
-				self.view.window().show_input_panel("boo!", '', '', None, None)
-				self.view.window().run_command('hide_panel');
+        for region in self.view.sel():
+            cursorPosition = region.begin()
+            previousCharacter = self.view.substr(sublime.Region(cursorPosition - 1, cursorPosition))
+
+            if '<' == previousCharacter and self.view.score_selector(cursorPosition, 'text.html | text.xml') > 0:
+                syntax = self.view.syntax_name(region.begin())
+                should_skip = re.match(".*string.quoted.double", syntax) or re.match(".*string.quoted.single", syntax)
+
+                if not should_skip:
+                    # found match, run close_tag here
+                    self.view.run_command('close_tag')
+
+                    if self.view.sel()[0].begin() != cursorPosition:
+                        # close_tag completed, so remove the extra angle bracket
+                        self.view.erase(edit, sublime.Region(cursorPosition - 1, cursorPosition))
+                    else:
+                        # we need to insert a slash
+                        self.view.insert(edit, cursorPosition, '/')
+
+                else:
+                    if region.empty():
+                        self.view.insert(edit, cursorPosition, '/')
+                    else:
+                        self.view.replace(edit, sublime.Region(region.begin(), region.end()), '/')
+
+            else:
+                if region.empty():
+                    self.view.insert(edit, cursorPosition, '/')
+                else:
+                    self.view.replace(edit, sublime.Region(region.begin(), region.end()), '/')
+


### PR DESCRIPTION
I like the `tag_close_tag_on_slash` functionality, but when I am in source files where `close_tag` will not work, I cannot manually type `</` because it gets erased. I made a slight modification to the python script to only erase the `</` if `close_tag` was successful. What do you think?

(Sorry about the white space change, SublimeLinter was complaining about the tabs)
