### PR TITLE
Added support for freemarker <#tag></#tag> -format.

### DIFF
--- a/Tag.py
+++ b/Tag.py
@@ -4,7 +4,7 @@ class Tag():
 
 	def __init__(self):
 
-		Tag.regexp_is_valid								= re.compile("^[a-z0-9\:\-_]+$", re.I);
+		Tag.regexp_is_valid								= re.compile("^[a-z0-9#\:\-_]+$", re.I);
 		Tag.regexp_self_closing_optional 	= re.compile("^<?(\?xml|\!|area|base|br|col|frame|hr|img|input|link|meta|param|command|embed|source|/?li|/?p)[^a-z]", re.I);
 		Tag.regexp_self_closing 					= re.compile("^<?(\?xml|\!|area|base|br|col|frame|hr|img|input|link|meta|param|command|embed|source)[^a-z]", re.I);
 		Tag.regexp_self_closing_xml   		= re.compile("^<?(\?xml|\!)[^a-z]", re.I);

--- a/tag_indent.py
+++ b/tag_indent.py
@@ -10,8 +10,8 @@ aditional_new_lines_re = re.compile("^\s*\n+\s*\n+\s*$")
 # no indentation
 no_indent = re.compile("^</?(head|body)[>| ]", re.I)
 
-# possible self closing tags:      XML------HTML------------------------------------------------HTML5----------------
-self_closing_tags = re.compile("^<(\?|\!|%|area|base|br|col|frame|hr|img|input|link|meta|param|command|embed|source)", re.I)
+# possible self closing tags:      XML-------HTML------------------------------------------------HTML5----------------
+self_closing_tags = re.compile("^<(\?|\!|%|#|area|base|br|col|frame|hr|img|input|link|meta|param|command|embed|source)", re.I)
 
 skip_content_of_this_tags_re = re.compile("^<(script|style|pre|code)(>| )", re.I)
 


### PR DESCRIPTION
Auto-closing tags on slash didn't support <#tag> format. Adding # to accepted letters inside tags seemed to remedy this problem. I'm not sure if the plugin is meant to support many template formats, but for me this was a necessary change.
