### PR TITLE
Fixed inconsistent use of tabs and spaces for python 3.3 and sublime text 3

### DIFF
--- a/tag_remove_attributes.py
+++ b/tag_remove_attributes.py
@@ -14,8 +14,8 @@ def TagRemoveAttributesSelected(data, attributes, view):
 	for attribute in attributes.split(' '):
 		if attribute:
 			regexp = re.compile('(<([a-z0-9\:\-_]+\s+)([^>]*)\s*'+re.escape(attribute)+'="[^"]+"\s*([^>]*)>)')
-		 	data = regexp.sub('<\\2\\3\\4>', data);
-		 	data = TagRemoveAttributesClean(data);
+			data = regexp.sub('<\\2\\3\\4>', data);
+			data = TagRemoveAttributesClean(data);
 	return data;
 
 class TagRemoveAllAttributesInSelectionCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
replaced mixed tabs and spaces in the TagRemoveAttributesSelected method if attribute: statement 
